### PR TITLE
Configure mti device on startup

### DIFF
--- a/src/xsens_driver/config/xsens.yaml
+++ b/src/xsens_driver/config/xsens.yaml
@@ -1,0 +1,28 @@
+# Serial device
+device: /dev/ttyUSB0
+
+# Baudrate. If configure_on_startup is true, will set device to use baudrate
+baudrate: 230400
+
+# Frame id which is assigned to all sensor data messages
+frame_id: xsens
+
+# Will configure the device on startup
+configure_on_startup: true
+
+# Output data rate of device. Valid values: 1, 2, 4, 5, 10, 20, 40, 50, 80, 100, 200, 400
+odr: 40
+
+# xkf-scenario
+# general: 39
+# high_mag_dep: 40
+# dynamic: 41
+# low_mag_dep: 42
+# vru_general: 43 (only profile available for mti-20)
+xkf_scenario: 43
+
+# Output data mode
+# 1: sensor data
+# 2. sensor data w/ rate quantities
+# 3: filter estimates
+output_mode: 2

--- a/src/xsens_driver/config/xsens.yaml
+++ b/src/xsens_driver/config/xsens.yaml
@@ -26,3 +26,6 @@ xkf_scenario: 43
 # 2. sensor data w/ rate quantities
 # 3: filter estimates
 output_mode: 2
+
+# Use rostime for IMU stamp instead of sensor reported time
+use_rostime: true

--- a/src/xsens_driver/launch/xsens.launch
+++ b/src/xsens_driver/launch/xsens.launch
@@ -1,0 +1,6 @@
+<launch>
+    <node name="xsens_mti30" pkg="xsens_driver" type="mtnode.py">
+        <remap from="mti/sensor/imu" to="imu/data_raw"/>
+        <rosparam command="load" file="$(find xsens_driver)/config/xsens.yaml"/>
+    </node>
+</launch>

--- a/src/xsens_driver/launch/xsens.launch
+++ b/src/xsens_driver/launch/xsens.launch
@@ -1,6 +1,5 @@
 <launch>
-    <node name="xsens_mti30" pkg="xsens_driver" type="mtnode.py">
-        <remap from="mti/sensor/imu" to="imu/data_raw"/>
+    <node name="xsens_mti" pkg="xsens_driver" type="mtnode.py">
         <rosparam command="load" file="$(find xsens_driver)/config/xsens.yaml"/>
     </node>
 </launch>

--- a/src/xsens_driver/src/mtdef.py
+++ b/src/xsens_driver/src/mtdef.py
@@ -124,7 +124,7 @@ class MID:
 	SetNoRotation = 0x22
 	
 	## Some timeout related stuff
-	additionalTimeOutOffset = 0.010 # 6ms
+	additionalTimeOutOffset = 0.020 # 6ms
 
 
 def getName(cls, value):

--- a/src/xsens_driver/src/mtdef.py
+++ b/src/xsens_driver/src/mtdef.py
@@ -124,7 +124,7 @@ class MID:
 	SetNoRotation = 0x22
 	
 	## Some timeout related stuff
-	additionalTimeOutOffset = 0.020 # 6ms
+	additionalTimeOutOffset = 0.010 # 6ms
 
 
 def getName(cls, value):

--- a/src/xsens_driver/src/mtnode.py
+++ b/src/xsens_driver/src/mtnode.py
@@ -68,7 +68,7 @@ class XSensDriver(object):
 
 		if configure_on_startup:
 			rospy.loginfo('Setting ODR (%d) and output mode (%d)' % (odr, output_mode))
-			if odr not in [1, 2, 5, 10, 20, 40, 50, 80, 10, 200, 400]:
+			if odr not in [1, 2, 5, 10, 20, 40, 50, 80, 100, 200, 400]:
 				raise Exception('Invalid ODR configuraton requested')
 			if output_mode not in [1, 2, 3]:
 				raise Exception('Invalid output mode requested')

--- a/src/xsens_driver/src/mtnode.py
+++ b/src/xsens_driver/src/mtnode.py
@@ -71,7 +71,7 @@ class XSensDriver(object):
 				raise Exception('Invalid ODR configuraton requested')
 			if output_mode not in [1, 2, 3]:
 				raise Exception('Invalid output mode requested')
-                        self.mt.configureMti(odr, output_mode)
+			self.mt.configureMti(odr, output_mode)
 			self.mt.ChangeBaudrate(baudrate)
 			self.mt.SetCurrentScenario(xkf_scenario)
 			self.mt.GoToMeasurement()

--- a/src/xsens_driver/src/mtnode.py
+++ b/src/xsens_driver/src/mtnode.py
@@ -60,6 +60,24 @@ class XSensDriver(object):
 		rospy.loginfo("MT node interface: %s at %d bd."%(device, baudrate))
 		self.mt = mtdevice.MTDevice(device, baudrate)
 
+		configure_on_startup = get_param('~configure_on_startup', False)
+		odr = get_param('~odr', 40)
+		output_mode = get_param('~output_mode', 2)
+                xkf_scenario = get_param('~xkf_scenario', 43)
+
+		if configure_on_startup:
+			rospy.loginfo('Setting ODR (%d) and output mode (%d)' % (odr, output_mode))
+			if odr not in [1, 2, 5, 10, 20, 40, 50, 80, 10, 200, 400]:
+				raise Exception('Invalid ODR configuraton requested')
+			if output_mode not in [1, 2, 3]:
+				raise Exception('Invalid output mode requested')
+                        self.mt.configureMti(odr, output_mode)
+			self.mt.ChangeBaudrate(baudrate)
+                        self.mt.SetCurrentScenario(xkf_scenario)
+                        self.mt.GoToMeasurement()
+		else:
+			rospy.loginfo('Using saved odr and output configuration')
+
 		self.frame_id = get_param('~frame_id', 'mti/data')
 
 		frame_local     = get_param('~frame_local'    , 'ENU')
@@ -364,7 +382,7 @@ class XSensDriver(object):
 
 def main():
 	'''Create a ROS node and instantiate the class.'''
-	rospy.init_node('xsens_driver', anonymous=True, log_level=rospy.WARN)
+	rospy.init_node('xsens_driver', anonymous=True, log_level=rospy.INFO)
 	driver = XSensDriver()
 	driver.spin()
 

--- a/src/xsens_driver/src/mtnode.py
+++ b/src/xsens_driver/src/mtnode.py
@@ -64,6 +64,7 @@ class XSensDriver(object):
 		odr = get_param('~odr', 40)
 		output_mode = get_param('~output_mode', 2)
 		xkf_scenario = get_param('~xkf_scenario', 43)
+		self.use_rostime = get_param('~use_rostime', False)
 
 		if configure_on_startup:
 			rospy.loginfo('Setting ODR (%d) and output mode (%d)' % (odr, output_mode))
@@ -322,10 +323,10 @@ class XSensDriver(object):
 		# publish available information
 		if pub_imu:
 			imu_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			imu_msg.header.stamp.secs = secs
-			imu_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				imu_msg.header.stamp.secs = secs
+				imu_msg.header.stamp.nsecs = nsecs	
 			self.imu_pub.publish(imu_msg)
 		#if pub_gps:
 		#	xgps_msg.header = gps_msg.header = h
@@ -338,45 +339,45 @@ class XSensDriver(object):
 		#	self.temp_pub.publish(temp_msg)
 		if pub_ss:
 			ss_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			ss_msg.header.stamp.secs = secs
-			ss_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				ss_msg.header.stamp.secs = secs
+				ss_msg.header.stamp.nsecs = nsecs	
 			self.ss_pub.publish(ss_msg)
 		if pub_baro:
 			baro_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			baro_msg.header.stamp.secs = secs
-			baro_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				baro_msg.header.stamp.secs = secs
+				baro_msg.header.stamp.nsecs = nsecs	
 			self.baro_pub.publish(baro_msg)
 		if pub_gnssPvt:
 			gnssPvt_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			baro_msg.header.stamp.secs = secs
-			baro_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				baro_msg.header.stamp.secs = secs
+				baro_msg.header.stamp.nsecs = nsecs	
 			self.gnssPvt_pub.publish(gnssPvt_msg)										
 		if pub_ori:
 			ori_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			ori_msg.header.stamp.secs = secs
-			ori_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				ori_msg.header.stamp.secs = secs
+				ori_msg.header.stamp.nsecs = nsecs	
 			self.ori_pub.publish(ori_msg)
 		if pub_vel:
 			vel_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			vel_msg.header.stamp.secs = secs
-			vel_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				vel_msg.header.stamp.secs = secs
+				vel_msg.header.stamp.nsecs = nsecs	
 			self.vel_pub.publish(vel_msg)
 		if pub_pos:
 			pos_msg.header = h
-			#all time assignments (overwriting ROS time)
-			# Comment the two lines below if you need ROS time
-			pos_msg.header.stamp.secs = secs
-			pos_msg.header.stamp.nsecs = nsecs	
+			if not self.use_rostime:
+				#all time assignments (overwriting ROS time)
+				pos_msg.header.stamp.secs = secs
+				pos_msg.header.stamp.nsecs = nsecs	
 			self.pos_pub.publish(pos_msg)		
 			
 

--- a/src/xsens_driver/src/mtnode.py
+++ b/src/xsens_driver/src/mtnode.py
@@ -63,7 +63,7 @@ class XSensDriver(object):
 		configure_on_startup = get_param('~configure_on_startup', False)
 		odr = get_param('~odr', 40)
 		output_mode = get_param('~output_mode', 2)
-                xkf_scenario = get_param('~xkf_scenario', 43)
+		xkf_scenario = get_param('~xkf_scenario', 43)
 
 		if configure_on_startup:
 			rospy.loginfo('Setting ODR (%d) and output mode (%d)' % (odr, output_mode))
@@ -73,8 +73,8 @@ class XSensDriver(object):
 				raise Exception('Invalid output mode requested')
                         self.mt.configureMti(odr, output_mode)
 			self.mt.ChangeBaudrate(baudrate)
-                        self.mt.SetCurrentScenario(xkf_scenario)
-                        self.mt.GoToMeasurement()
+			self.mt.SetCurrentScenario(xkf_scenario)
+			self.mt.GoToMeasurement()
 		else:
 			rospy.loginfo('Using saved odr and output configuration')
 


### PR DESCRIPTION
**Major Issue**
Wanted  to avoid having to complete the extra step of running mtdevice.py when bringing up a new device

**Improvements**
* Added optional device configuration to mtnode.py
* Created a sample launch file and yaml config file
* Modified readme to use the launch file instead of launching node seperately
* Added a parameter to support switching between ROS and system timestamps in sensor messages
* Changed log level to INFO to print out the loaded parameter values to make errors which occur by mismatching parameter namespaces more apparent

**Testing**
Tested with Mti-20 and Mti-30