### PR TITLE
Fix install by removing install rule for non-existent launch folder in xsens_msgs

### DIFF
--- a/src/xsens_driver/CMakeLists.txt
+++ b/src/xsens_driver/CMakeLists.txt
@@ -132,6 +132,11 @@ install(PROGRAMS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+install(
+  DIRECTORY launch config
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)
+
 ## Mark executables and/or libraries for installation
 # install(TARGETS test_py test_py_node
 #   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}

--- a/src/xsens_msgs/CMakeLists.txt
+++ b/src/xsens_msgs/CMakeLists.txt
@@ -151,10 +151,10 @@ include_directories(
 # )
 
 ## Mark other files for installation (e.g. launch and bag files, etc.)
-install(
-  DIRECTORY launch
-  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-)
+#install(
+#  DIRECTORY launch
+#  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+#)
 
 #############
 ## Testing ##


### PR DESCRIPTION
Remove install rule which clearly is wrong (likely copy and paste leftover). Without this fix, the catkin install step fails.